### PR TITLE
Small fixes in geopandas notebooks

### DIFF
--- a/_solved/01-introduction-tabular-data.ipynb
+++ b/_solved/01-introduction-tabular-data.ipynb
@@ -4209,7 +4209,7 @@
     "editable": true
    },
    "source": [
-    "This is only an ultra short intro to matplotlib. In the course materials, you can find another notebook with some more details ([visualization-01-matplotlib.ipynb](visualization_01_matplotlib.ipynb#An-small-cheat-sheet-reference-for-some-common-elements))."
+    "This is only an ultra short intro to matplotlib. In the course materials, you can find another notebook with some more details ([visualization-01-matplotlib.ipynb](visualization-01-matplotlib.ipynb#An-small-cheat-sheet-reference-for-some-common-elements))."
    ]
   },
   {
@@ -5911,7 +5911,14 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.8.10"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {},
+    "version_major": 2,
+    "version_minor": 0
+   }
   }
  },
  "nbformat": 4,

--- a/_solved/04-spatial-relationships-joins.ipynb
+++ b/_solved/04-spatial-relationships-joins.ipynb
@@ -2255,7 +2255,7 @@
    "cell_type": "code",
    "execution_count": 50,
    "metadata": {
-    "clear_cell": true
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -2267,7 +2267,7 @@
    "cell_type": "code",
    "execution_count": 51,
    "metadata": {
-    "clear_cell": true
+    "tags": []
    },
    "outputs": [
     {


### PR DESCRIPTION
Small fixes after the workshop:

- Properly fix the link to the matplotlib notebook
- Provide `trees_by_district.to_frame(name='n_trees')` as given (no clear cell)